### PR TITLE
Fix incorrect import

### DIFF
--- a/invokust/loadtest.py
+++ b/invokust/loadtest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import os
+import sys
 import gevent
 import json
 import signal


### PR DESCRIPTION
`os` is unused and `sys` is not imported below.