### PR TITLE
Separating AWS parts from the rest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 *.zip
 python-packages
+.terraform
 terraform.tfstate*
 invokust.egg-info
 dist

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Lambda function execution time is limited to a maximum of 5 minutes. To run a re
 
 ```python
 import logging
-from invokust import LambdaLoadTest
+from invokust.aws_lambda import LambdaLoadTest
 
 logging.basicConfig(level=logging.INFO)
 

--- a/invokr.py
+++ b/invokr.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import sys
 import json
-from invokust import LambdaLoadTest, results_aggregator
+from invokust.aws_lambda import LambdaLoadTest, results_aggregator
 
 def parse_arguments():
     p = argparse.ArgumentParser(description='Runs a Locust load tests on AWS Lambda in parallel')

--- a/invokust/__init__.py
+++ b/invokust/__init__.py
@@ -2,6 +2,3 @@
 
 from .settings import create_settings
 from .loadtest import LocustLoadTest
-from .aws_lambda import get_lambda_runtime_info
-from .aws_lambda import LambdaLoadTest
-from .aws_lambda import results_aggregator

--- a/lambda_locust.py
+++ b/lambda_locust.py
@@ -5,7 +5,8 @@ sys.path.insert(0, "python-packages")
 
 import logging
 import json
-from invokust import create_settings, LocustLoadTest, get_lambda_runtime_info
+from invokust.aws_lambda import get_lambda_runtime_info
+from invokust import LocustLoadTest, create_settings
 
 logging.basicConfig(level=logging.INFO)
 

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "aws_iam_policy_attachment" "lambda_basic_execution" {
 }
 
 resource "aws_lambda_function" "lambda_locust" {
-  filename      = "invokust_example.zip"
+  filename      = "lambda_locust.zip"
   function_name = "lambda_locust"
   role          = "${aws_iam_role.lambda_basic_execution.arn}"
   handler       = "lambda_locust.handler"


### PR DESCRIPTION
To stop the error:
```
botocore.exceptions.NoRegionError: You must specify a region.
```
When not using the AWS Lambda parts