### PR TITLE
Fix typo which broke the display of stats

### DIFF
--- a/invokust/aws_lambda/results_aggregator.py
+++ b/invokust/aws_lambda/results_aggregator.py
@@ -82,6 +82,6 @@ def results_aggregator(results):
     for task in failed_tasks:
         task_data_results = [stat['failures'][task] for stat in results if task in stat['failures']]
         agg_results['failures'][task] = task_data_results[0]
-        agg_results['failures'][task]['occurences'] = sum([stat['occurences'] for stat in task_data_results])
+        agg_results['failures'][task]['occurrences'] = sum([stat['occurrences'] for stat in task_data_results])
 
     return agg_results


### PR DESCRIPTION
Due to the typo, the following issue occurs.

```
Traceback (most recent call last):
...
...
  File "/Users/csillabessenyei/.local/share/virtualenvs/orion-sre-instar-m64UkkKW/lib/python3.7/site-packages/invokust/aws_lambda/results_aggregator.py", line 85, in results_aggregator
    agg_results['failures'][task]['occurences'] = sum([stat['occurences'] for stat in task_data_results])
  File "/Users/csillabessenyei/.local/share/virtualenvs/orion-sre-instar-m64UkkKW/lib/python3.7/site-packages/invokust/aws_lambda/results_aggregator.py", line 85, in <listcomp>
    agg_results['failures'][task]['occurences'] = sum([stat['occurences'] for stat in task_data_results])
KeyError: 'occurences'
```