### PR TITLE
Parameterise lambda timeout

### DIFF
--- a/invokust/aws_lambda/lambda_load_test.py
+++ b/invokust/aws_lambda/lambda_load_test.py
@@ -21,7 +21,7 @@ class LambdaLoadTest(object):
     An object to run and collect statistics and results from multiple parallel locust load
     tests running on AWS Lambda
     '''
-    def __init__(self, lambda_function_name, threads, ramp_time, time_limit, lambda_payload):
+    def __init__(self, lambda_function_name, threads, ramp_time, time_limit, lambda_payload, lambda_timeout=300000):
         self.lock = threading.Lock()
         self.start_time = time.time()
         self.logger = logging.getLogger()
@@ -41,6 +41,7 @@ class LambdaLoadTest(object):
         self.thread_data = {}
         self.print_stats_delay = 3
         self.exit_threads = False
+        self.lambda_timeout = lambda_timeout
 
     def update_thread_data(self, thread_id, key, value):
         '''
@@ -259,7 +260,7 @@ class LambdaLoadTest(object):
             results = json.loads(payload_json_str)
             function_duration = function_end_time - function_start_time
             total_rpm = results['num_requests'] / (function_duration / 60)
-            lambda_execution_time = 300000 - results['remaining_time']
+            lambda_execution_time = self.lambda_timeout - results['remaining_time']
 
             self.append_locust_results(results)
             self.increase_requests_fail(results['num_requests_fail'])

--- a/invokust/aws_lambda/results_aggregator.py
+++ b/invokust/aws_lambda/results_aggregator.py
@@ -2,7 +2,7 @@
 
 from numpy import histogram
 
-def results_aggregator(results):
+def results_aggregator(results, lambda_timeout=300000):
     '''
     Takes a list of many individual results and returns a dictionary of aggregated
     data.
@@ -54,7 +54,7 @@ def results_aggregator(results):
 
     request_tasks = _flatten_unique([list(stat['requests'].keys()) for stat in results])
     failed_tasks = _flatten_unique([list(stat['failures'].keys()) for stat in results])
-    total_lambda_execution_time = sum([(300000 - stat['remaining_time']) for stat in results])
+    total_lambda_execution_time = sum([(lambda_timeout - stat['remaining_time']) for stat in results])
     memory_limit = _get_max(results, 'memory_limit')
 
     agg_results = {

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ with open("README.md", "r") as fh:
 
 setup(
     name = 'invokust',
-    version = '0.72',
+    version = '0.73',
     author = 'Max Williams',
     author_email = 'futuresharks@gmail.com',
     description = 'A small wrapper for locust to allow running load tests from within Python or on AWS Lambda',
     long_description=long_description,
     long_description_content_type="text/markdown",
     url = 'https://github.com/FutureSharks/invokust',
-    download_url  =  'https://github.com/FutureSharks/invokust/archive/0.72.tar.gz',
+    download_url  =  'https://github.com/FutureSharks/invokust/archive/0.73.tar.gz',
     license = 'MIT',
     scripts = ['invokr.py'],
     packages = [


### PR DESCRIPTION
I'd like this to be added. When you run lambdas with longer timeout, the execution time will be negative.